### PR TITLE
add line number for scenario outlines

### DIFF
--- a/index.js
+++ b/index.js
@@ -62,7 +62,7 @@ function saveEmbeddedImages(destPath, element, steps) {
     if (step.embeddings) {
       step.embeddings.forEach(function(embedding) {
         if (embedding.mime_type === 'image/png') {
-          var imageName = createFileName(element.name) + '.png';
+          var imageName = createFileName(element.name + ':' + element.line) + '.png';
           var fileName = path.join(destPath, imageName);
           // Save imageName on element so we use it in HTML
           element.imageName = imageName;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cucumber-html-report",
-  "version": "0.2.9",
+  "version": "0.2.10",
   "description": "Convert cucumber reports from json to HTML using Mustache templates",
   "homepage": "https://github.com/leinonen/cucumber-html-report",
   "author": {


### PR DESCRIPTION
@leinonen not sure if you have this in the pipeline but I had an issue with scenario outlines and that it would overwrite the previous example since you are just using the name of the element, so my simple solution is just to add the line number to the image name.  Not sure if that works for you or not, but figured I would submit this just in case someone else needs this.  Let me know if there are any issues with it.  Thanks!