### PR TITLE
Remove non-word chars from filenames to prevent errors on (at least) Windows

### DIFF
--- a/index.js
+++ b/index.js
@@ -110,7 +110,7 @@ function loadTemplate(templateFile) {
 }
 
 function createFileName(name) {
-  return name.split(' ').join('_').toLowerCase();
+  return name.split('\W+').join('_').toLowerCase();
 }
 
 function writeImage(fileName, data) {


### PR DESCRIPTION
Just got caught by this:

```
Error: ENOENT: no such file or directory, open 'D:\src\thin-monitor2\reports\e2e\classify_by_"country_of_trade",_"asset_type",_and_"s&p_ratings".png'
    at Error (native)
    at Object.fs.openSync (fs.js:584:18)
    at Object.fs.writeFileSync (fs.js:1224:33)
    at writeImage (D:\src\thin-monitor2\node_modules\cucumber-html-report\index.js:117:6)
    at D:\src\thin-monitor2\node_modules\cucumber-html-report\index.js:69:11
    at Array.forEach (native)
    at D:\src\thin-monitor2\node_modules\cucumber-html-report\index.js:63:23
    at Array.forEach (native)
    at saveEmbeddedImages (D:\src\thin-monitor2\node_modules\cucumber-html-report\index.js:61:9)
    at D:\src\thin-monitor2\node_modules\cucumber-html-report\index.js:29:9
    at Array.forEach (native)
    at D:\src\thin-monitor2\node_modules\cucumber-html-report\index.js:28:23
    at Array.forEach (native)
    at CucumberHtmlReport.createReport (D:\src\thin-monitor2\node_modules\cucumber-html-report\index.js:25:11)
    at Gulp.<anonymous> (D:\src\thin-monitor2\gulp-tasks\testing-tasks.js:275:5)
    at module.exports (D:\src\thin-monitor2\node_modules\orchestrator\lib\runTask.js:34:7)
```