### PR TITLE
UX: when document width <= 500px

### DIFF
--- a/templates/default.html
+++ b/templates/default.html
@@ -169,6 +169,21 @@
     }
 
     .footer a, footer a:visited { color: #3C494C; }
+
+    @media (max-width: 500px) {
+      .feature-navigator {
+        position: relative;
+        height: auto;
+        width: 100%;
+        clear: both;
+        overflow: auto;
+      }
+      .report-container {
+        margin-top: 1em;
+        margin-left: auto;
+        width: 100%
+      }
+    }
   </style>
   <title>{{title}}</title>
 </head>


### PR DESCRIPTION
UX: when document width <= 500px, put the `.feature-navigator` above the `.report-container`