### PR TITLE
Extensible options object

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,6 +7,11 @@ var
   Directory = require('./lib/directory'),
   Summary = require('./lib/summary');
 
+  //Object.assign polyfill for older node versions
+  if (!Object.assign) {
+    Object.assign = require('object-assign');
+  }
+
 var defaultTemplate = path.join(__dirname, 'templates', 'default.html');
 
 var CucumberHtmlReport = module.exports = function(options) {

--- a/index.js
+++ b/index.js
@@ -22,14 +22,14 @@ CucumberHtmlReport.prototype.createReport = function() {
   var features = parseFeatures(options, loadCucumberReport(this.options.source));
   var templateFile = options.template || defaultTemplate;
   var template = loadTemplate(templateFile);
-  var mustacheOptions = {
+  var mustacheOptions = Object.assign(options, {
     title: options.title || 'Cucumber Report',
     component: options.component || '',
     features: features,
     summary: Summary.calculateSummary(features),
     image: mustacheImageFormatter,
     duration: mustacheDurationFormatter
-  };
+  });
 
   var html = Mustache.to_html(template, mustacheOptions);
   saveHTML(options.dest, options.name, html);

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   "dependencies": {
     "atob": "^2.0.3",
     "mustache": "^2.2.0",
+    "object-assign": "^4.1.0",
     "slug": "^0.9.1"
   },
   "devDependencies": {


### PR DESCRIPTION
The options object is now passed to mustache with all of its properties, and any extra properties on it will be visible on the template. This makes things like adding an image to the template, with its src set from a separate js file possible through the options object.

Before, only the title and component properties have been passed to mustache and the template.