### PR TITLE
Duration in Seconds rather than nano seconds

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,7 +33,7 @@ CucumberHtmlReport.prototype.createReport = function() {
     features: features,
     summary: Summary.calculateSummary(features),
     image: mustacheImageFormatter,
-    duration: mustacheDurationFormatter
+    duration: durationInSeconds
   });
 
   var html = Mustache.to_html(template, mustacheOptions);
@@ -183,5 +183,19 @@ function mustacheDurationFormatter() {
   // https://groups.google.com/forum/#!topic/cukes/itAKGVwJHFg
   return function(text, render) {
     return render(text);
+  };
+}
+
+function durationInSeconds() {
+
+  return function(text, render) {  
+    var text =render(text);
+    var elapsedTime = text / 1000000000;
+    if (elapsedTime >= 60) {
+            data = parseInt(elapsedTime / 60) + 'm ' + (elapsedTime % 60).toFixed(0) + 's';
+        } else {
+            data =  elapsedTime.toFixed(2) + 's';
+        }      
+    return data;
   };
 }


### PR DESCRIPTION
Cucumber report json creates duration in **nano-seconds** by default, many of us do not need the duration of steps at that accuracy level. Moreover a 7 digit duration in reports look ugly and confusing to people. Therefore in reports we could convert them to **seconds** by default!