### PR TITLE
Improve embedings

### DIFF
--- a/cucumber-html-report.js
+++ b/cucumber-html-report.js
@@ -383,6 +383,13 @@ function saveEmbeddedMetadata(destPath, element, steps) {
           var decodedText = atob(embedding.data);
           element.plainTextMetadata.push(decodedText);
         }
+        else if (embedding.mime_type === 'text/html') {
+          // Save html text on element so we use as embeded HTML
+          element.htmlTextMetadata = element.htmlTextMetadata || [];
+
+          var decodedText = atob(embedding.data);
+          element.htmlTextMetadata.push(decodedText);
+        }
       });
     }
   });

--- a/cucumber-html-report.js
+++ b/cucumber-html-report.js
@@ -370,11 +370,12 @@ function saveEmbeddedMetadata(destPath, element, steps) {
     if (step.embeddings) {
       step.embeddings.forEach(function(embedding) {
         if (embedding.mime_type === "image/png") {
-          var imageName = createFileName(element.name + "-" + element.line) + ".png";
-          var fileName = path.join(destPath, imageName);
-          // Save imageName on element so we use it in HTML
-          element.imageName = imageName;
-          writeImage(fileName, embedding.data);
+          // var imageName = createFileName(element.name + '-' + element.line) + '.png';
+          // var fileName = path.join(destPath, imageName);
+          // // Save imageName on element so we use it in HTML
+          // element.imageName = imageName;
+          // writeImage(fileName, embedding.data);
+          element.inlineImage = embedding;
         }
         else if (embedding.mime_type === "text/plain") {
           // Save plain text on element so we use it in HTML

--- a/src/default.html
+++ b/src/default.html
@@ -163,7 +163,8 @@
 
         </table>
 
-        {{#plainTextMetadata}}<p>{{.}}</p>{{/plainTextMetadata}}
+        {{#plainTextMetadata}}<p><pre>{{.}}</pre>{{/plainTextMetadata}}
+        {{#htmlTextMetadata}}<p>{{{.}}}</p>{{/htmlTextMetadata}}
         {{#image}}{{imageName}}{{/image}}
         {{/elements}}
       </section>

--- a/src/default.html
+++ b/src/default.html
@@ -165,7 +165,7 @@
 
         {{#plainTextMetadata}}<p><pre>{{.}}</pre>{{/plainTextMetadata}}
         {{#htmlTextMetadata}}<p>{{{.}}}</p>{{/htmlTextMetadata}}
-        {{#image}}{{imageName}}{{/image}}
+        {{#inlineImage}}<img src="data:{{mime_type}};base64,{{data}}"/>{{/inlineImage}}
         {{/elements}}
       </section>
       {{/features}}


### PR DESCRIPTION
Add ability to embed HTML text as well as plain text.  Use case embedding HTML table.
Change images to use the provided base64 data directly in the html as a data URI, which makes the report a complete singe file document, and avoids need to write file to disk or generate a filename.