### PR TITLE
Added report sort disabling feature

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cucumber-html-report",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Convert cucumber json reports to a pretty html report.",
   "homepage": "https://github.com/leinonen/cucumber-html-report",
   "author": {

--- a/src/report.js
+++ b/src/report.js
@@ -44,6 +44,10 @@ exports.validate = function (options) {
       options.maxScreenshots = 1000
     }
 
+    if (!options.hasOwnProperty('sortReport') || typeof options.sortReport === 'undefined') {
+      options.sortReport = true
+    }
+
     resolve(options)
   })
 }
@@ -272,15 +276,24 @@ function loadCucumberJson (fileName) {
   return JSON.parse(fs.readFileSync(fileName, 'utf-8').toString())
 }
 
-function sortByStatusAndName (list) {
-  return R.sortWith([
+function sortByStatusAndName (list, options) {
+  var sortArray = [
     R.ascend(R.prop('status')),
     R.ascend(R.prop('name'))
-  ], list)
+  ]
+
+  /* If the option sortReport is false leave the report sorted by execution chronology */
+  if (!options.sortReport) {
+    sortArray = [
+      R.ascend(R.prop('line'))
+    ]
+  }
+
+  return R.sortWith(sortArray, list)
 }
 
 function sortScenariosForFeature (feature) {
-  feature.elements = sortByStatusAndName(feature.elements)
+  feature.elements = sortByStatusAndName(feature.elements, this)
   return feature
 }
 
@@ -289,7 +302,7 @@ function parseFeatures (options, features) {
     .map(getFeatureStatus)
     .map(parseTags)
     .map(processScenarios(options))
-    .map(sortScenariosForFeature))
+    .map(sortScenariosForFeature, options), options)
 }
 
 function createFileName (name) {

--- a/src/report.spec.js
+++ b/src/report.spec.js
@@ -71,6 +71,12 @@ reportNames.forEach(reportName =>
           expect(opts.maxScreenshots).to.equal(1000)
         })
       })
+
+      it('should set sortReport if not specified', () => {
+        return Report.validate(options).then(opts => {
+          expect(opts.sortReport).to.equal(true)
+        })
+      })
     })
 
     describe('Create directory', () => {


### PR DESCRIPTION
* You can now disable the sorting of the report by setting the option sortReport to false to your configuration.