### PR TITLE
Fix encoding of browser logs in Cucumber 3.

### DIFF
--- a/src/report.js
+++ b/src/report.js
@@ -410,7 +410,7 @@ function handleEmbeddingPlainText (embedding, element) {
 }
 
 function handleEmbeddingBrowserLog (embedding, element) {
-  element.logs = new Buffer(embedding.data, 'base64').toString('ascii').split('\n')
+  element.logs = embedding.data.split('\n');
 }
 
 function mustacheImageFormatter () {

--- a/src/report.js
+++ b/src/report.js
@@ -410,7 +410,7 @@ function handleEmbeddingPlainText (embedding, element) {
 }
 
 function handleEmbeddingBrowserLog (embedding, element) {
-  element.logs = embedding.data.split('\n');
+  element.logs = embedding.data.split('\n')
 }
 
 function mustacheImageFormatter () {


### PR DESCRIPTION
Buffer scrambles plain text in Cucumber3, so just rely on plain text instead.